### PR TITLE
idcp.localhost should not be the hardcoded value. Instead use the doc…

### DIFF
--- a/rootfs/opt/templates/config.yaml.template
+++ b/rootfs/opt/templates/config.yaml.template
@@ -6,7 +6,7 @@ hypercube:
   pdftotext_executable: pdftotext
 
 fedora_resource:
-  base_url: http://idcp.localhost:8080/fcrepo/rest
+  base_url: http://fcrepo:8080/fcrepo/rest
 
 log:
   # Valid log levels are:


### PR DESCRIPTION
…ker-compose service name e.g. fcrepo which should never change