### PR TITLE
Using base image, confd, and s6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,9 @@
-FROM php:7.4.3-apache
+FROM isle-crayfish-base:latest
 # Apache https://github.com/docker-library/php/blob/04c0ee7a0277e0ebc3fcdc46620cf6c1f6273100/7.4/buster/apache/Dockerfile
 
-## General Dependencies & Poppler-utils
-# poppler-utils https://packages.debian.org/buster/poppler-utils
-RUN GEN_DEP_PACKS="software-properties-common \
-    gnupg \
-    zip \
-    unzip \
-    git \
-    gettext-base \
-    poppler-utils" && \
-    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
-    apt-get install --no-install-recommends -y $GEN_DEP_PACKS && \
-    ## Cleanup phase.
-    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-## Tesseract 
+## Tesseract and pdftotext
 # @see: https://packages.debian.org/buster/tesseract-ocr
+# @see: https://packages.debian.org/buster/poppler-utils
 
 RUN TESSERACT_PACKS="tesseract-ocr \
     tesseract-ocr-eng \
@@ -29,7 +14,8 @@ RUN TESSERACT_PACKS="tesseract-ocr \
     tesseract-ocr-hin \
     tesseract-ocr-deu \
     tesseract-ocr-jpn \
-    tesseract-ocr-rus" && \
+    tesseract-ocr-rus \
+    poppler-utils" && \
     apt-get update && \
     apt-get install --no-install-recommends -y $TESSERACT_PACKS && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
@@ -42,9 +28,6 @@ COPY rootfs /
 # @see: Composer https://github.com/composer/getcomposer.org/commits/master (replace hash below with most recent hash)
 # @see: Hypercube https://github.com/Islandora/Crayfish
 
-ARG HYPERCUBE_JWT_ADMIN_TOKEN
-ARG HYPERCUBE_LOG_LEVEL
-
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
     COMPOSER_ALLOW_SUPERUSER=1 \
     COMPOSER_HASH=${COMPOSER_HASH:-b9cc694e39b669376d7a033fb348324b945bce05} \
@@ -55,26 +38,14 @@ RUN curl https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_HA
     rm composer-setup.php && \
     mkdir -p /opt/crayfish && \
     git clone -b $HYPERCUBE_BRANCH https://github.com/Islandora/Crayfish.git /opt/crayfish && \
-    cp /opt/crayfish/Hypercube/cfg/config.example.yaml /opt/crayfish/Hypercube/cfg/config.yaml && \
     composer install -d /opt/crayfish/Hypercube && \
     chown -Rv www-data:www-data /opt/crayfish && \
     mkdir /var/log/islandora && \
     chown www-data:www-data /var/log/islandora && \
-    envsubst < /opt/templates/syn-settings.xml.template > /opt/crayfish/Hypercube/syn-settings.xml && \
-    envsubst < /opt/templates/config.yaml.template > /opt/crayfish/Hypercube/cfg/config.yaml && \
     a2dissite 000-default && \
     #echo "ServerName localhost" | tee /etc/apache2/conf-available/servername.conf && \
     #a2enconf servername && \
     a2enmod rewrite deflate headers expires proxy proxy_http proxy_html proxy_connect remoteip xml2enc cache_disk
-
-## jwt
-# https://github.com/qadan/documentation/blob/installation/docs/installation/manual/configuring_drupal.md 
-
-## syn ?
-# https://github.com/Islandora/Crayfish/blob/dev/Hypercube/cfg/config.example.yaml 
-
-## logging ?
-# https://github.com/Islandora/Crayfish/blob/dev/Hypercube/cfg/config.example.yaml
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -89,11 +60,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"
 
-ENTRYPOINT ["docker-php-entrypoint"]
-
-STOPSIGNAL SIGWINCH
-
 WORKDIR /opt/crayfish/Hypercube/
-
-EXPOSE 8000
-CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Designed to used with:
 
 Based on:
 
-* Official PHP Apache image: [php:7.4.3-apache](https://hub.docker.com/layers/php/library/php/7.4.3-apache/images/sha256-48dde1707d7dca2b701aa230344c58cb8ec5b0ce8e9dbceced65bec5ccd7d1d0?context=explore)
+* [isle-crayfish-base](https://github.com/Islandora-Devops/isle-crayfish-base)
 
 Contains and includes:
 
@@ -26,23 +26,6 @@ Contains and includes:
 * [Poppler Utils](https://poppler.freedesktop.org/)
 * [Hypercube](https://github.com/Islandora/Crayfish/tree/dev/Hypercube)
 
-## MVP 2 sprint
-
-### Building
-
-There are two build arguments that you must provide in order to build this container:
-
-* HYPERCUBE_JWT_ADMIN_TOKEN - An easy to remember token to replace an actual JWT when testing (usually "islandora")
-* HYPERCUBE_LOG_LEVEL - Logging level for the Hypercube microservice (DEBUG, INFO, WARN, ERROR, etc...)
-
-In order to build, run this command
-
-* `docker build -t isle-hypercube --build-arg HYPERCUBE_JWT_ADMIN_TOKEN=islandora --build-arg HYPERCUBE_LOG_LEVEL=DEBUG .`
-
-Or if you've defined the build args as environment variables already, simply
-
-* `docker build -t isle-hypercube --build-arg HYPERCUBE_JWT_ADMIN_TOKEN --build-arg HYPERCUBE_LOG_LEVEL .`
-
 ### Running
 
 To run the container, you'll need to bind mount two things:
@@ -50,11 +33,16 @@ To run the container, you'll need to bind mount two things:
 * A public key from the key pair used to sign and verify JWT tokens at `/opt/keys/public.key`
 * A `php.ini` file with output buffering enabled at `/usr/local/etc/php/php.ini`
 
-* `docker run -d -p 8000:8000 -v /path/to/public.key:/opt/keys/public.key -v /path/to/php.ini:/usr/local/etc/php/php.ini isle-hypercube`
+You'll also want to set two environment variables, which affect configuration of the microservice
+
+* HYPERCUBE_JWT_ADMIN_TOKEN - An easy to remember token to replace an actual JWT when testing (usually "islandora")
+* HYPERCUBE_LOG_LEVEL - Logging level for the Hypercube microservice (DEBUG, INFO, WARN, ERROR, etc...)
+
+`docker run -d -p 8000:8000 -e HYPERCUBE_JWT_ADMIN_TOKEN=islandora -e HYPERCUBE_LOG_LEVEL=DEBUG -v /path/to/public.key:/opt/keys/public.key -v /path/to/php.ini:/usr/local/etc/php/php.ini isle-houdini`
 
 ### Testing
 
-To test Homarus, you can issue a curl command against it to verify its endpoint is working.  For example, to run OCR on a sample TIFF:
+To test Hypercube, you can issue a curl command against it to verify its endpoint is working.  For example, to run OCR on a sample TIFF:
 
 * `curl -i -H "Authorization: Bearer islandora" -H "Apix-Ldp-Resource: https://www.fileformat.info/format/tiff/sample/3794038f08df403bb446a97f897c578d/download" idcp.localhost:8000`
 

--- a/rootfs/etc/confd/conf.d/config.toml
+++ b/rootfs/etc/confd/conf.d/config.toml
@@ -1,0 +1,7 @@
+[template]
+src = "config.yaml.tpl"
+dest = "/opt/crayfish/Hypercube/cfg/config.yaml"
+mode = "0644"
+keys = [
+    "/hypercube/log/level",
+]

--- a/rootfs/etc/confd/conf.d/syn-settings.toml
+++ b/rootfs/etc/confd/conf.d/syn-settings.toml
@@ -1,0 +1,7 @@
+[template]
+src = "syn-settings.xml.tpl"
+dest = "/opt/crayfish/Hypercube/syn-settings.xml"
+mode = "0644"
+keys = [
+    "/hypercube/jwt/admin/token",
+]

--- a/rootfs/etc/confd/templates/config.yaml.tpl
+++ b/rootfs/etc/confd/templates/config.yaml.tpl
@@ -12,7 +12,7 @@ log:
   # Valid log levels are:
   # DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY, NONE
   # log level none won't open logfile
-  level: $HYPERCUBE_LOG_LEVEL
+  level: {{getv "/hypercube/log/level"}}
   file: ../hypercube.log
 
 syn:

--- a/rootfs/etc/confd/templates/syn-settings.xml.tpl
+++ b/rootfs/etc/confd/templates/syn-settings.xml.tpl
@@ -3,6 +3,6 @@
 <config version='1'>
     <site algorithm='RS256' encoding='PEM' path='/opt/jwt/public.key' default='true' anonymous='true'/>
     <token user='admin' roles='admin'>
-        $HYPERCUBE_JWT_ADMIN_TOKEN
+        {{getv "/hypercube/jwt/admin/token"}}
     </token>
 </config>


### PR DESCRIPTION
## Testing

I tested this by following the README. I built with
`docker build -t isle-hypercube .`

and then ran it with this (note I bind mounted in some files from isle-dc)
`docker run -d -p 8000:8000 -e HYPERCUBE_JWT_ADMIN_TOKEN=islandora -e HYPERCUBE_LOG_LEVEL=DEBUG -v ~/Code/Environments/isle-dc/config/jwt/public.key:/opt/keys/public.key -v ~/Code/Environments/isle-dc/config/crayfish/php.ini:/usr/local/etc/php/php.ini isle-hypercube`

Then I ran tesseract on an image with this:
`curl -i -H "Authorization: Bearer islandora" -H "Apix-Ldp-Resource: https://www.fileformat.info/format/tiff/sample/3794038f08df403bb446a97f897c578d/download" idcp.localhost:8000`